### PR TITLE
remove random path from macro llib

### DIFF
--- a/leptos-spin-macro/src/lib.rs
+++ b/leptos-spin-macro/src/lib.rs
@@ -17,4 +17,3 @@ pub fn server(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
         Ok(s) => s.to_token_stream().into(),
     }
 }
-/Users/sam/Projects/start-spin/src


### PR DESCRIPTION
remove the random path erroneously inserted into the leptos-spin-macro's lib.rs file